### PR TITLE
add dependency on the Stopwatch component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "description": "A pack for the Symfony web profiler",
     "require": {
         "php": "^7.0",
+        "symfony/stopwatch": "^3.3",
         "symfony/twig-bundle": "^3.3",
         "symfony/web-profiler-bundle": "^3.3"
     }


### PR DESCRIPTION
This is the counterpart of symfony/symfony#23148. Using the profiler without the Stopwatch component makes it lack a lot of useful information. However, in production you will probably not need it all. Thus, I suggest to require the component in the profiler pack to allow the FrameworkBundle to drop the dependency and thus decreasing the required deps for the production environment.