### PR TITLE
Remove php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "description": "A pack for the Symfony web profiler",
     "require": {
-        "php": "^7.0",
         "symfony/stopwatch": "*",
         "symfony/twig-bundle": "*",
         "symfony/web-profiler-bundle": "*"


### PR DESCRIPTION
In an experimental project using PHP 8.0, I've tried to install the `symfony/profiler-pack` but it's not possible because of the PHP constraint sets in the `composer.json`.

However each dependency of the pack seems to be PHP 8.0 ready. I've installed all packages individually and the profiler works.

I think, you should remove the PHP constraint and let Composer resolving dependencies with the required dependencies constraints.